### PR TITLE
Another hash database fix

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -102,9 +102,14 @@ if [ "$1" = "-t" ]; then
 	  sort >test/"tt$id"
 	if sort <"test/a$id" | diff -wi - "test/tt$id" >/dev/null; then
 	    result=OK
-	    if [ -n "$sec" ] && grep -q "$zone" test/trust.keys; then
-		delv -a test/trust.keys +tcp +short +root="$zone" +rtrace +nodlv @"$SERVER" $name$zone $typea >/dev/null 2>&1 \
-		  || result="FAIl: delv validation"
+	    if [ -n "$sec" -a "$1" = "-u" ] && grep -q "$zone" test/trust.keys; then
+		truncate -s 0 "test/dt$id"
+		echo ".$id" \
+		  | grep -qE '.-(0[2679]|2[346])' \
+		  || delv -a test/trust.keys +tcp +short +root="$zone" +nodlv @"$SERVER" $name$zone $type >"test/dt$id" 2>&1
+		grep -vE 'failed.*nx(domain|rrset)' "test/dt$id" \
+		  | grep -i fail \
+		  && result="FAIl: delv validation"
 	    fi
 	else
 	    result="FAIL: dig +notcp"
@@ -136,8 +141,13 @@ if [ "$1" = "-u" ]; then
 	if sort <"test/a$id" | diff -wi - "test/tu$id" >/dev/null; then
 	    result=OK
 	    if [ -n "$sec" ] && grep -q "$zone" test/trust.keys; then
-		delv -a test/trust.keys +notcp +short +root="$zone" +rtrace +nodlv @"$SERVER" $name$zone $typea >/dev/null 2>&1 \
-		  || result="FAIl: delv validation"
+		truncate -s 0 "test/du$id"
+		echo ".$id" \
+		  | grep -qE '.-(0[2679]|2[346])' \
+		  || delv -a test/trust.keys +notcp +short +root="$zone" +nodlv @"$SERVER" $name$zone $type >"test/du$id" 2>&1
+		grep -vE 'failed.*nx(domain|rrset)' "test/dt$id" \
+		  | grep -i fail \
+		  && result="FAIl: delv validation"
 	    fi
 	else
 	    result="FAIL: dig +notcp"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -101,10 +101,15 @@ if [ "$1" = "-t" ]; then
 	sed -s 's/\b[0-9]\{10\}\b/<TIME>/g;s/\b[0-9]\{14\}\b/<TIME>/g;/00 RRSIG /s/[^ ]*$/<SIG>/' <test/"ttt$id" | \
 	  sort >test/"tt$id"
 	if sort <"test/a$id" | diff -wi - "test/tt$id" >/dev/null; then
-	    echo "OK"
+	    result=OK
+	    if [ -n "$sec" ] && grep -q "$zone" test/trust.keys; then
+		delv -a test/trust.keys +tcp +short +root="$zone" +rtrace +nodlv @"$SERVER" $name$zone $typea >/dev/null 2>&1 \
+		  || result="FAIl: delv validation"
+	    fi
 	else
-	    echo "FAIL: dig +tcp"
+	    result="FAIL: dig +notcp"
 	fi
+	echo "$result"
     done
 fi
 
@@ -129,10 +134,15 @@ if [ "$1" = "-u" ]; then
 	sed -s 's/\b[0-9]\{10\}\b/<TIME>/g;s/\b[0-9]\{14\}\b/<TIME>/g;/00 RRSIG /s/[^ ]*$/<SIG>/' <test/"tut$id" | \
 	  sort >test/"tu$id"
 	if sort <"test/a$id" | diff -wi - "test/tu$id" >/dev/null; then
-	    echo "OK"
+	    result=OK
+	    if [ -n "$sec" ] && grep -q "$zone" test/trust.keys; then
+		delv -a test/trust.keys +notcp +short +root="$zone" +rtrace +nodlv @"$SERVER" $name$zone $typea >/dev/null 2>&1 \
+		  || result="FAIl: delv validation"
+	    fi
 	else
-	    echo "FAIL: dig +notcp"
+	    result="FAIL: dig +notcp"
 	fi
+	echo "$result"
     done
 fi
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -30,6 +30,11 @@ set -e
 ##########################################
 # Test example zones and tinydns responses
 
+( echo "managed-keys {";
+  grep '^#K[^:]*:257:' test/data \
+    | sed 's=^#K\([^:]*\):\([0-9]*\):\([0-9]*\):\([0-9]*\):\([^:]*\):.*= \1 initial-key \2 \3 \4 "\5";='
+  echo "};" ) >test/trust.keys
+
 ./tinydns-sign.pl test/example.?sk <test/data >data
 ./tinydns-data
 rm data
@@ -37,8 +42,8 @@ rm data
 for i in test/q-*; do
     id="${i#test/q}"
     echo -n "$i ... "
-    read sec type name <"$i"
-    ./tinydns-get "$sec" "$type" $name | tail -n +2 >test/"o$id"
+    read name zone type sec <"$i"
+    ./tinydns-get $sec "$type" $name$zone | tail -n +2 >test/"o$id"
     sed -s 's/\b[0-9]\{10\}\b/<TIME>/g;/00 RRSIG /s/[^ ]*$/<SIG>/;s/^[0-9]\{1,\}/<SIZE>/' <test/"o$id" >test/"t$id"
     if diff "test/t$id" "test/a$id" >/dev/null; then
 	echo "OK"
@@ -85,13 +90,13 @@ if [ "$1" = "-t" ]; then
     for i in test/q-*; do
 	id="${i#test/q}"
 	echo -n "$i (tcp) ... "
-	read sec type name <"$i"
+	read name zone type sec <"$i"
 	if [ "$sec" = "-s" ]; then
 	    sec="+dnssec +bufsize=1220"
 	elif [ "$sec" = "-S" ]; then
 	    sec="+dnssec +bufsize=2000"
 	fi
-	dig +norecurse +tcp $sec "$type" $name @$SERVER >"test/ot$id"
+	dig +norecurse +tcp $sec "$type" $name$zone @$SERVER >"test/ot$id"
 	dig2tiny "test/ot$id" "test/ttt$id"
 	sed -s 's/\b[0-9]\{10\}\b/<TIME>/g;s/\b[0-9]\{14\}\b/<TIME>/g;/00 RRSIG /s/[^ ]*$/<SIG>/' <test/"ttt$id" | \
 	  sort >test/"tt$id"
@@ -113,13 +118,13 @@ if [ "$1" = "-u" ]; then
     for i in test/q-*; do
 	id="${i#test/q}"
 	echo -n "$i (udp) ... "
-	read sec type name <"$i"
+	read name zone type sec <"$i"
 	if [ "$sec" = "-s" ]; then
 	    sec="+dnssec +bufsize=1220"
 	elif [ "$sec" = "-S" ]; then
 	    sec="+dnssec +bufsize=2000"
 	fi
-	dig +norecurse +notcp $sec "$type" $name @$SERVER >"test/ou$id"
+	dig +norecurse +notcp $sec "$type" $name$zone @$SERVER >"test/ou$id"
 	dig2tiny "test/ou$id" "test/tut$id"
 	sed -s 's/\b[0-9]\{10\}\b/<TIME>/g;s/\b[0-9]\{14\}\b/<TIME>/g;/00 RRSIG /s/[^ ]*$/<SIG>/' <test/"tut$id" | \
 	  sort >test/"tu$id"

--- a/test/a-48
+++ b/test/a-48
@@ -1,0 +1,11 @@
+<SIZE> bytes, 1+0+8+1 records, response, authoritative, nxdomain
+query: A 23.bug-201907.xx
+authority: bug-201907.xx 2500 SOA ns1.bug-201907.xx bugs.bug-201907.xx <TIME> 3600 300 3600000 3600
+authority: bug-201907.xx 2500 RRSIG SOA 7 2 2500 <TIME> <TIME> 44495 bug-201907.xx <SIG>
+authority: mommf7eoir860kafe2svq3skg8931ter.bug-201907.xx 86400 NSEC3 1 0 12 AABBCCDD nktouv25ij58mqjbrnv5chn5tp0os33e NS SOA RRSIG DNSKEY NSEC3PARAM
+authority: mommf7eoir860kafe2svq3skg8931ter.bug-201907.xx 86400 RRSIG NSEC3 7 3 86400 <TIME> <TIME> 44495 bug-201907.xx <SIG>
+authority: jlvi3gvq4und75uno2669hta94qjuf8d.bug-201907.xx 86400 NSEC3 1 0 12 AABBCCDD mommf7eoir860kafe2svq3skg8931ter A RRSIG
+authority: jlvi3gvq4und75uno2669hta94qjuf8d.bug-201907.xx 86400 RRSIG NSEC3 7 3 86400 <TIME> <TIME> 44495 bug-201907.xx <SIG>
+authority: vu6o9jbv9vgkspu0cser5248i4717i3c.bug-201907.xx 86400 NSEC3 1 0 12 AABBCCDD 5k5q9fve7svr623nqk9k81jb4eumftgc MX RRSIG
+authority: vu6o9jbv9vgkspu0cser5248i4717i3c.bug-201907.xx 86400 RRSIG NSEC3 7 3 86400 <TIME> <TIME> 44495 bug-201907.xx <SIG>
+additional: . 0 OPT 512 0 0 8000

--- a/test/q-01
+++ b/test/q-01
@@ -1,2 +1,2 @@
--s mx x.w.example
+x.w. example mx -s
 # RFC-4035 Appendix B.1

--- a/test/q-02
+++ b/test/q-02
@@ -1,2 +1,2 @@
--s mx mc.a.example
+mc.a. example mx -s
 # RFC-4035 Appendix B.4

--- a/test/q-03
+++ b/test/q-03
@@ -1,2 +1,2 @@
--s a a.c.x.w.example
+a.c.x.w. example a -s
 # RFC-5155 Appendix B.1

--- a/test/q-04
+++ b/test/q-04
@@ -1,2 +1,2 @@
--s mx ns1.example
+ns1. example mx -s
 # RFC-5155 Appendix B.2

--- a/test/q-05
+++ b/test/q-05
@@ -1,2 +1,2 @@
--s a y.w.example
+y.w. example a -s
 # RFC-5155 Appendix B.2.1

--- a/test/q-06
+++ b/test/q-06
@@ -1,2 +1,2 @@
--s mx a.z.w.example
+a.z.w. example mx -s
 # RFC-5155 Appendix B.4

--- a/test/q-07
+++ b/test/q-07
@@ -1,2 +1,2 @@
--S mx a.z.w.example
+a.z.w. example mx -S
 # RFC-5155 Appendix B.4

--- a/test/q-08
+++ b/test/q-08
@@ -1,2 +1,2 @@
--s aaaa a.z.w.example
+a.z.w. example aaaa -s
 # RFC-5155 Appendix B.5

--- a/test/q-09
+++ b/test/q-09
@@ -1,2 +1,2 @@
--s ds example
+\  example ds -s
 # RFC-5155 Appendix B.6

--- a/test/q-10
+++ b/test/q-10
@@ -1,1 +1,1 @@
-mx x.w.example
+x.w. example mx

--- a/test/q-11
+++ b/test/q-11
@@ -1,1 +1,1 @@
-mx mc.a.example
+mc.a. example mx

--- a/test/q-12
+++ b/test/q-12
@@ -1,1 +1,1 @@
-a a.c.x.w.example
+a.c.x.w. example a

--- a/test/q-13
+++ b/test/q-13
@@ -1,1 +1,1 @@
-mx ns1.example
+ns1. example mx

--- a/test/q-14
+++ b/test/q-14
@@ -1,1 +1,1 @@
-a y.w.example
+y.w. example a

--- a/test/q-15
+++ b/test/q-15
@@ -1,1 +1,1 @@
-mx a.z.w.example
+a.z.w. example mx

--- a/test/q-16
+++ b/test/q-16
@@ -1,1 +1,1 @@
-aaaa a.z.w.example
+a.z.w. example aaaa

--- a/test/q-17
+++ b/test/q-17
@@ -1,1 +1,1 @@
-ds example
+\  example ds

--- a/test/q-18
+++ b/test/q-18
@@ -1,1 +1,1 @@
-mx an.example.xx
+an. example.xx mx

--- a/test/q-19
+++ b/test/q-19
@@ -1,1 +1,1 @@
-mx another.example.xx
+another. example.xx mx

--- a/test/q-20
+++ b/test/q-20
@@ -1,1 +1,1 @@
-mx simple.example.xx
+simple. example.xx mx

--- a/test/q-21
+++ b/test/q-21
@@ -1,1 +1,1 @@
-mx sub.example.xx
+sub. example.xx mx

--- a/test/q-22
+++ b/test/q-22
@@ -1,1 +1,1 @@
-a simple.example.xx
+simple. example.xx a

--- a/test/q-23
+++ b/test/q-23
@@ -1,1 +1,1 @@
--s mx an.example.xx
+an. example.xx mx -s

--- a/test/q-24
+++ b/test/q-24
@@ -1,1 +1,1 @@
--s mx another.example.xx
+another. example.xx mx -s

--- a/test/q-25
+++ b/test/q-25
@@ -1,1 +1,1 @@
--s mx simple.example.xx
+simple. example.xx mx -s

--- a/test/q-26
+++ b/test/q-26
@@ -1,1 +1,1 @@
--s mx sub.example.xx
+sub. example.xx mx -s

--- a/test/q-27
+++ b/test/q-27
@@ -1,1 +1,1 @@
--s a simple.example.xx
+simple. example.xx a -s

--- a/test/q-28
+++ b/test/q-28
@@ -1,1 +1,1 @@
-cname an.example.xx
+an. example.xx cname

--- a/test/q-29
+++ b/test/q-29
@@ -1,1 +1,1 @@
--s cname an.example.xx
+an. example.xx cname -s

--- a/test/q-30
+++ b/test/q-30
@@ -1,1 +1,1 @@
-aaaa a.ns.unsigned.xx
+a.ns. unsigned.xx aaaa

--- a/test/q-31
+++ b/test/q-31
@@ -1,1 +1,1 @@
--s aaaa a.ns.unsigned.xx
+a.ns. unsigned.xx aaaa -s

--- a/test/q-32
+++ b/test/q-32
@@ -1,1 +1,1 @@
-a nx.unsigned.xx
+nx. unsigned.xx a

--- a/test/q-33
+++ b/test/q-33
@@ -1,1 +1,1 @@
--s a nx.unsigned.xx
+nx. unsigned.xx a -s

--- a/test/q-34
+++ b/test/q-34
@@ -1,1 +1,1 @@
-mx wc.w.unsigned.xx
+wc.w. unsigned.xx mx

--- a/test/q-35
+++ b/test/q-35
@@ -1,1 +1,1 @@
--s mx wc.w.unsigned.xx
+wc.w. unsigned.xx mx -s

--- a/test/q-36
+++ b/test/q-36
@@ -1,1 +1,1 @@
-mx an.unsigned.xx
+an. unsigned.xx mx

--- a/test/q-37
+++ b/test/q-37
@@ -1,1 +1,1 @@
--s mx an.unsigned.xx
+an. unsigned.xx mx -s

--- a/test/q-38
+++ b/test/q-38
@@ -1,1 +1,1 @@
-mx another.unsigned.xx
+another. unsigned.xx mx

--- a/test/q-39
+++ b/test/q-39
@@ -1,1 +1,1 @@
--s mx another.unsigned.xx
+another. unsigned.xx mx -s

--- a/test/q-40
+++ b/test/q-40
@@ -1,1 +1,1 @@
--s hinfo xx.example
+xx. example hinfo -s

--- a/test/q-41
+++ b/test/q-41
@@ -1,2 +1,2 @@
--s a www.a.bug-201907.xx
+www.a. bug-201907.xx a -s
 # Buggy wildcard handling reported in 2019-07, depends on RR order in data.cdb file

--- a/test/q-42
+++ b/test/q-42
@@ -1,2 +1,2 @@
--s aaaa www.b.bug-201907.xx
+www.b. bug-201907.xx aaaa -s
 # Buggy wildcard handling reported in 2019-07, depends on RR order in data.cdb file

--- a/test/q-43
+++ b/test/q-43
@@ -1,2 +1,2 @@
--s mx www.c.bug-201907.xx
+www.c. bug-201907.xx mx -s
 # Buggy wildcard handling reported in 2019-07, depends on RR order in data.cdb file

--- a/test/q-44
+++ b/test/q-44
@@ -1,2 +1,2 @@
--s a 1.bug-202005.xx
+1. bug-202005.xx a -s
 # Hash database in [0-9a-f].domain shadows top-level wildcard *.domain

--- a/test/q-45
+++ b/test/q-45
@@ -1,2 +1,2 @@
--s a sub.1.bug-202005.xx
+sub.1. bug-202005.xx a -s
 # Hash database in [0-9a-f].domain shadows top-level wildcard *.domain

--- a/test/q-46
+++ b/test/q-46
@@ -1,2 +1,2 @@
-a 1.bug-202005.xx
+1. bug-202005.xx a
 # Hash database in [0-9a-f].domain shadows top-level wildcard *.domain

--- a/test/q-47
+++ b/test/q-47
@@ -1,2 +1,2 @@
-a sub.1.bug-202005.xx
+sub.1. bug-202005.xx a
 # Hash database in [0-9a-f].domain shadows top-level wildcard *.domain

--- a/test/q-48
+++ b/test/q-48
@@ -1,0 +1,2 @@
+23. bug-201907.xx a -s
+# First entry in hash database has wrong predecessor

--- a/tinydns-sign.pl
+++ b/tinydns-sign.pl
@@ -254,7 +254,7 @@ foreach my $zone (@main::zones) {
     }
     $prev->{next} = $first->{hash};
     unshift @{$byNibble[0]}, $prev->{hash};
-    for (my $nib = 1; $nib <= $#byNibble && $#{$byNibble[$nib]} < 0; $nib++) {
+    for (my $nib = 1; $nib <= $#byNibble && $#{$byNibble[$nib - 1]} < 1; $nib++) {
 	unshift @{$byNibble[$nib]}, $prev->{hash};
     }
     for (my $nib = $#byNibble + 1; $nib < 16; $nib++) {


### PR DESCRIPTION
The purpose of the hash database is to find the NSEC3 record covering a given name. An NSEC3 record with an RR name *X* and a next hash value *Y* covers a name *n* if *X <= H(n) < Y* (or if *Y < X* then either *X < H(n)* or *H(n) < Y*). *X* and *Y* are neighbouring hashes of existing RR names. So given a name *n*, we want to find the greatest *X* such that either *X <= H(n)* or for the *Y* of the corresponding NSEC3 RR *Y < X* and *H(n) < Y*.
The hash database contains for each high-order nybble all possible candidates for *X* such that the above condition is met for any *H(n)* starting with that nybble.
Or at least it should but didn't in all cases.